### PR TITLE
fix: Fixed a hidden logging bug in add_tokenize_docs in word_count.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ You should also add project tags for each release in Github, see [Managing relea
 ## [Unreleased]
 ### Changed
 - GitHub workflow for linting and formatting uses ruff as a separate job
-
+- Fixed Logging bug in `add_tokenize_docs` in `word_count.py`
 ### Removed
 - GitHub action to run flake8 for linting in build
 - Removed wildcard from corpus-counter script dependency

--- a/src/cdstemplate/word_count.py
+++ b/src/cdstemplate/word_count.py
@@ -60,7 +60,7 @@ class CorpusCounter:
             logger.info("Adding %s token(s) case insensitively", len(token_list))
             self.token_counter.update([w.lower() for w in non_empty_tokens])
         else:
-            logger.info("Adding %s token(s) case insensitively", len(token_list))
+            logger.info("Adding %s token(s) case sensitively", len(token_list))
             self.token_counter.update(non_empty_tokens)
         after_vocab_size = self.get_vocab_size()
 


### PR DESCRIPTION
I fixed a hidden logging bug in word_count.py in `add_tokenize_docs` where it was incorrectly logging the case sensitive case as case insensitive.

Original
![image](https://github.com/user-attachments/assets/b9ef89f6-9f51-4f1f-b43f-fd67f8463b4c)

Fix:
![image](https://github.com/user-attachments/assets/59729792-cfdf-4d73-8643-8708e53d306b)
